### PR TITLE
use standard 1EU -> 4RF/FE conversion

### DIFF
--- a/config/gtadditions.cfg
+++ b/config/gtadditions.cfg
@@ -302,8 +302,8 @@ general {
 
         # True if you want Energy Converter to accept batteries with same voltage as the Energy Converter. False if you want Energy Converter to accept any tier of batteries.
         B:PermitOnlyExactVoltage=false
-        I:"Ratio 1 EU to X RF"=1
-        I:"Ratio X RF to 1 EU"=1
+        I:"Ratio 1 EU to X RF"=4
+        I:"Ratio X RF to 1 EU"=4
 
         # Whether or not to disable GregTech EU to RF energy converters.
         B:disableEUtoRF=false

--- a/config/gtadditions.cfg
+++ b/config/gtadditions.cfg
@@ -302,8 +302,8 @@ general {
 
         # True if you want Energy Converter to accept batteries with same voltage as the Energy Converter. False if you want Energy Converter to accept any tier of batteries.
         B:PermitOnlyExactVoltage=false
-        I:"Ratio 1 EU to X RF"=4
-        I:"Ratio X RF to 1 EU"=4
+        I:"Ratio 1 EU to X RF"=2
+        I:"Ratio X RF to 1 EU"=1
 
         # Whether or not to disable GregTech EU to RF energy converters.
         B:disableEUtoRF=false


### PR DESCRIPTION
Mods assume this conversion rate and hardcode it, and people in the discord assumed it as well.  AE2 can be made to display its power consumption in RF, AE, or EU, and it hardcodes the 1:2:4 conversion rates, meaning that its EU output is wrong (it's 25% what you put in).