### PR TITLE
allow players to break creative xu2 items

### DIFF
--- a/config/extrautils2.cfg
+++ b/config/extrautils2.cfg
@@ -2,7 +2,7 @@
 
 "creative blocks: breakable" {
     # Allow Non-Creative players to break/harvest creative blocks. [default: false]
-    B:gameplay=false
+    B:gameplay=true
 }
 
 


### PR DESCRIPTION
Fixes issue where creative mill can be crafted and placed, but not moved.