### PR TITLE
re-enable pulse centrifuge from lazy_ae2

### DIFF
--- a/scripts/disabled.zs
+++ b/scripts/disabled.zs
@@ -66,7 +66,7 @@ static disabledItems as IIngredient[][string] = {
         <extracells:part.base:5>,
         <extracells:part.base:6>,
         <extracells:part.base:9>,
-        <threng:machine:1>,
+        # <threng:machine:1>,
         <threng:machine:2>,
         <threng:machine:5>
     ],


### PR DESCRIPTION
currently there's a bug (that I can't reproduce) where none of the ae2 autoclave seed growth recipes are working.

Combined with clearlag script removing items, this makes it impossible to properly automate ae2 seed growth.  There are..  4 possible options to fix/work around this issue, this PR is the simplest work around as the normal recipes do appear to work in single player and elsewhere:

1. enable the lazy ae2 pulse centrifuge which has recipes for this (the recipe uses lazy ae2 components & ae2 components that are aleady gregified)
2. fix the autoclave issue w/ seed growth on the community server
3. add an alternate autoclave recipe (eg fluix dust -> 2 pure fluix, certus dust -> 2 pure certus)
4. add `appliedenergistics2` to the clearlag mod id blacklist 

4 is...  not a great option, because automating that is _much_ more involved and power hungry than any of the other options. Each growth accelerator uses 1600EU/t due to the way that ae2 and eu/rf conversion is configured.