### PR TITLE
Remove Errored Recipe Removal

### DIFF
--- a/scripts/gregtech/recipes.zs
+++ b/scripts/gregtech/recipes.zs
@@ -256,16 +256,7 @@ function machineRecipes() {
     gt.alloy_smelter.recipeBuilder().duration(4800).EUt(16384).notConsumable(<gregtech:meta_item_1:32304>).inputs([<gregtech:meta_item_1:13047>*8]).outputs([<gregtech:meta_item_1:32005>]).buildAndRegister();
     gt.alloy_smelter.recipeBuilder().duration(4800).EUt(65536).notConsumable(<gregtech:meta_item_1:32304>).inputs([<gregtech:meta_item_1:13307>*8]).outputs([<gregtech:meta_item_1:32006>]).buildAndRegister();
     gt.alloy_smelter.recipeBuilder().duration(4800).EUt(262144).notConsumable(<gregtech:meta_item_1:32304>).inputs([<gregtech:meta_item_1:13993>*8]).outputs([<gregtech:meta_item_1:32007>]).buildAndRegister();
-
-    // Fix recipe conflict
-    gt.chemical_reactor.findRecipe(30, [null], [<liquid:ammonia> * 1000, <liquid:hypochlorous_acid> * 1000]).remove();
-    gt.chemical_reactor.recipeBuilder()
-        .fluidInputs([<liquid:ammonia> * 1000, <liquid:hypochlorous_acid> * 1000])
-        .notConsumable(gt.getCirc(1))
-        .fluidOutputs([<liquid:water> * 1000, <liquid:chloramine> * 1000])
-        .duration(sec(8)).EUt(30)
-        .buildAndRegister();
-} 
+}
 
 function init() {
 	// Un-named recipes


### PR DESCRIPTION
This removed a recipe to simply put a circuit in it to avoid a recipe conflict. This is no longer needed due to updates to either GTCE or Gregicality.

However, this recipe removal erroring is causing a significant amount of scripts to fail on launch, so this PR is essential to be released as a hotfix. With these changes, there are no issues with CT loading in ver. 5.1