### PR TITLE
0.22 Update

### DIFF
--- a/config/ftbquests/normal/chapters/0789a99a/2ed2c0f1.snbt
+++ b/config/ftbquests/normal/chapters/0789a99a/2ed2c0f1.snbt
@@ -1,0 +1,43 @@
+{
+	title: "Steam Multiblock Parts",
+	x: -5.0d,
+	y: 0.0d,
+	description: "Don't use these in other places!",
+	text: [
+		"The Steam Multiblocks require special buses and hatches to use.",
+		"",
+		"The Steam Hatch is used to power the multiblock, and must be provided with Steam to run the multiblock.",
+		"The Steam Input/Output Buses are just like normal buses, but can only be used in steam multiblocks."
+	],
+	dependencies: [
+		"a165aeb9",
+		"dad8af63"
+	],
+	or_tasks: true,
+	tasks: [{
+		uid: "78b35acf",
+		type: "item",
+		items: [{
+			item: "gregtech:machine 1 4175"
+		}]
+	},
+	{
+		uid: "33fdd9b8",
+		type: "item",
+		items: [{
+			item: "gregtech:machine 1 4176"
+		}]
+	},
+	{
+		uid: "e01ccd93",
+		type: "item",
+		items: [{
+			item: "gregtech:machine 1 4177"
+		}]
+	}],
+	rewards: [{
+		uid: "6843c5ac",
+		type: "ftbmoney:money",
+		ftb_money: 7L
+	}]
+}

--- a/config/ftbquests/normal/chapters/0789a99a/a165aeb9.snbt
+++ b/config/ftbquests/normal/chapters/0789a99a/a165aeb9.snbt
@@ -1,0 +1,23 @@
+{
+	x: -4.0d,
+	y: -1.0d,
+	description: "A Multiblock Macerator at the Steam Era",
+	text: [
+		"The Steam Grinder can run up to 8 recipes at a time, for only 1.33x the steam consumption of the Steam Macerator, and only 1.5x the duration!"
+	],
+	dependencies: [
+		"506ea84f"
+	],
+	tasks: [{
+		uid: "747d9ef7",
+		type: "item",
+		items: [{
+			item: "gregtech:machine 1 4178"
+		}]
+	}],
+	rewards: [{
+		uid: "b65905f5",
+		type: "ftbmoney:money",
+		ftb_money: 10L
+	}]
+}

--- a/config/ftbquests/normal/chapters/0789a99a/dad8af63.snbt
+++ b/config/ftbquests/normal/chapters/0789a99a/dad8af63.snbt
@@ -1,0 +1,23 @@
+{
+	x: -4.0d,
+	y: 1.0d,
+	description: "Not the Railcraft Steam Oven",
+	text: [
+		"The Steam Oven is similar to the Steam Grinder. Up to 8 items at a time, for only 1.33x the Steam and 1.5x the duration of the Steam Furnace."
+	],
+	dependencies: [
+		"506ea84f"
+	],
+	tasks: [{
+		uid: "c30252c4",
+		type: "item",
+		items: [{
+			item: "gregtech:machine 1 4197"
+		}]
+	}],
+	rewards: [{
+		uid: "b475551d",
+		type: "ftbmoney:money",
+		ftb_money: 10L
+	}]
+}

--- a/config/ftbquests/normal/chapters/12c8772d/1751cc60.snbt
+++ b/config/ftbquests/normal/chapters/12c8772d/1751cc60.snbt
@@ -2,7 +2,7 @@
 	x: -2.0d,
 	y: 0.5d,
 	dependencies: [
-		"1e5e4d5f"
+		"36e2ce29"
 	],
 	tasks: [{
 		uid: "1f164f50",

--- a/config/ftbquests/normal/chapters/12c8772d/36e2ce29.snbt
+++ b/config/ftbquests/normal/chapters/12c8772d/36e2ce29.snbt
@@ -1,0 +1,14 @@
+{
+	x: -3.0d,
+	y: 0.5d,
+	dependencies: [
+		"7fbf669a"
+	],
+	tasks: [{
+		uid: "0769f7c8",
+		type: "item",
+		items: [{
+			item: "gtadditions:ga_meta_item 1 32411"
+		}]
+	}]
+}

--- a/config/ftbquests/normal/chapters/12c8772d/7fbf669a.snbt
+++ b/config/ftbquests/normal/chapters/12c8772d/7fbf669a.snbt
@@ -1,0 +1,14 @@
+{
+	x: -3.0d,
+	y: -0.5d,
+	dependencies: [
+		"69ad2d27"
+	],
+	tasks: [{
+		uid: "e88a77f4",
+		type: "item",
+		items: [{
+			item: "gtadditions:ga_meta_item 1 32035"
+		}]
+	}]
+}

--- a/config/ftbquests/normal/chapters/37345452/1f5901e4.snbt
+++ b/config/ftbquests/normal/chapters/37345452/1f5901e4.snbt
@@ -118,8 +118,11 @@
 		"70f81a04"
 	],
 	tasks: [{
-		uid: "d4b009d7",
-		type: "checkmark"
+		uid: "1fb8af55",
+		type: "item",
+		items: [{
+			item: "gregtech:meta_item_1 1 10672"
+		}]
 	}],
 	rewards: [{
 		uid: "8f15453c",

--- a/config/ftbquests/normal/chapters/37345452/247800d5.snbt
+++ b/config/ftbquests/normal/chapters/37345452/247800d5.snbt
@@ -2,10 +2,10 @@
 	x: 4.0d,
 	y: 4.5d,
 	tasks: [{
-		uid: "dcef41c6",
+		uid: "ca7d5dae",
 		type: "item",
 		items: [{
-			item: "minecraft:barrier"
+			item: "gregtech:meta_item_1 1 10683"
 		}]
 	}]
 }

--- a/config/ftbquests/normal/chapters/37345452/267c949a.snbt
+++ b/config/ftbquests/normal/chapters/37345452/267c949a.snbt
@@ -2,10 +2,10 @@
 	x: 13.0d,
 	y: 4.5d,
 	tasks: [{
-		uid: "f84ea25a",
+		uid: "3a755757",
 		type: "item",
 		items: [{
-			item: "minecraft:barrier"
+			item: "gregtech:meta_item_1 1 10681"
 		}]
 	}]
 }

--- a/config/ftbquests/normal/chapters/37345452/2759862a.snbt
+++ b/config/ftbquests/normal/chapters/37345452/2759862a.snbt
@@ -2,10 +2,10 @@
 	x: 14.0d,
 	y: 4.5d,
 	tasks: [{
-		uid: "c6b6e1a1",
+		uid: "35339b4e",
 		type: "item",
 		items: [{
-			item: "minecraft:barrier"
+			item: "gregtech:meta_item_1 1 10707"
 		}]
 	}]
 }

--- a/config/ftbquests/normal/chapters/37345452/341d56d1.snbt
+++ b/config/ftbquests/normal/chapters/37345452/341d56d1.snbt
@@ -2,10 +2,10 @@
 	x: 2.0d,
 	y: 4.5d,
 	tasks: [{
-		uid: "f07dcafb",
+		uid: "062be6cd",
 		type: "item",
 		items: [{
-			item: "minecraft:barrier"
+			item: "gregtech:meta_item_1 1 10736"
 		}]
 	}]
 }

--- a/config/ftbquests/normal/chapters/37345452/51be8d6c.snbt
+++ b/config/ftbquests/normal/chapters/37345452/51be8d6c.snbt
@@ -2,10 +2,10 @@
 	x: 3.0d,
 	y: 4.5d,
 	tasks: [{
-		uid: "52d3008e",
+		uid: "de2f76e1",
 		type: "item",
 		items: [{
-			item: "minecraft:barrier"
+			item: "gregtech:meta_item_1 1 10735"
 		}]
 	}]
 }

--- a/config/ftbquests/normal/chapters/37345452/5f916a07.snbt
+++ b/config/ftbquests/normal/chapters/37345452/5f916a07.snbt
@@ -2,10 +2,10 @@
 	x: 7.0d,
 	y: 4.5d,
 	tasks: [{
-		uid: "a389fe01",
+		uid: "7478d522",
 		type: "item",
 		items: [{
-			item: "minecraft:barrier"
+			item: "gregtech:meta_item_1 1 10677"
 		}]
 	}]
 }

--- a/config/ftbquests/normal/chapters/37345452/72a8acec.snbt
+++ b/config/ftbquests/normal/chapters/37345452/72a8acec.snbt
@@ -2,10 +2,10 @@
 	x: -3.0d,
 	y: 4.5d,
 	tasks: [{
-		uid: "57f12534",
+		uid: "365f8b17",
 		type: "item",
 		items: [{
-			item: "gregtech:meta_item_1 1 2767"
+			item: "gregtech:meta_item_1 1 10767"
 		}]
 	}]
 }

--- a/config/ftbquests/normal/chapters/37345452/85d3463c.snbt
+++ b/config/ftbquests/normal/chapters/37345452/85d3463c.snbt
@@ -2,10 +2,10 @@
 	x: 9.0d,
 	y: 4.5d,
 	tasks: [{
-		uid: "df7bc50f",
+		uid: "e99f3b32",
 		type: "item",
 		items: [{
-			item: "minecraft:barrier"
+			item: "gregtech:meta_item_1 1 10678"
 		}]
 	}]
 }

--- a/config/ftbquests/normal/chapters/37345452/8b429bd6.snbt
+++ b/config/ftbquests/normal/chapters/37345452/8b429bd6.snbt
@@ -2,10 +2,10 @@
 	x: 10.0d,
 	y: 4.5d,
 	tasks: [{
-		uid: "1d9d17e6",
+		uid: "66dd9d74",
 		type: "item",
 		items: [{
-			item: "minecraft:barrier"
+			item: "gregtech:meta_item_1 1 10706"
 		}]
 	}]
 }

--- a/config/ftbquests/normal/chapters/37345452/d12afd1d.snbt
+++ b/config/ftbquests/normal/chapters/37345452/d12afd1d.snbt
@@ -2,10 +2,10 @@
 	x: 5.0d,
 	y: 4.5d,
 	tasks: [{
-		uid: "a4af9696",
+		uid: "356075fe",
 		type: "item",
 		items: [{
-			item: "minecraft:barrier"
+			item: "gregtech:meta_item_1 1 10676"
 		}]
 	}]
 }

--- a/config/ftbquests/normal/chapters/37345452/e8a38a84.snbt
+++ b/config/ftbquests/normal/chapters/37345452/e8a38a84.snbt
@@ -2,10 +2,10 @@
 	x: 12.0d,
 	y: 4.5d,
 	tasks: [{
-		uid: "9067558d",
+		uid: "a51a3692",
 		type: "item",
 		items: [{
-			item: "minecraft:barrier"
+			item: "gregtech:meta_item_1 1 10680"
 		}]
 	}]
 }

--- a/config/ftbquests/normal/chapters/37345452/f9fc0dda.snbt
+++ b/config/ftbquests/normal/chapters/37345452/f9fc0dda.snbt
@@ -2,10 +2,10 @@
 	x: 11.0d,
 	y: 4.5d,
 	tasks: [{
-		uid: "099e3775",
+		uid: "bb6b6272",
 		type: "item",
 		items: [{
-			item: "minecraft:barrier"
+			item: "gregtech:meta_item_1 1 10679"
 		}]
 	}]
 }

--- a/config/ftbquests/normal/chapters/406f3274/1a3f6ee8.snbt
+++ b/config/ftbquests/normal/chapters/406f3274/1a3f6ee8.snbt
@@ -7,7 +7,7 @@
 	],
 	dependencies: [
 		"d472ca3a",
-		"1e5e4d5f"
+		"69ad2d27"
 	],
 	tasks: [{
 		uid: "f487d9ba",

--- a/config/ftbquests/normal/chapters/406f3274/69ad2d27.snbt
+++ b/config/ftbquests/normal/chapters/406f3274/69ad2d27.snbt
@@ -1,0 +1,18 @@
+{
+	title: "Insane Circuit Board",
+	x: 4.0d,
+	y: 3.5d,
+	text: [
+		""
+	],
+	dependencies: [
+		"9674bc92"
+	],
+	tasks: [{
+		uid: "e4e0ad43",
+		type: "item",
+		items: [{
+			item: "gtadditions:ga_meta_item 1 32585"
+		}]
+	}]
+}

--- a/manifest.json
+++ b/manifest.json
@@ -643,7 +643,7 @@
     },
     {
       "projectID": 293327,
-      "fileID": 3249033,
+      "fileID": 3266351,
       "required": true
     },
     {
@@ -663,7 +663,7 @@
     },
     {
       "projectID": 364851,
-      "fileID": 3236714,
+      "fileID": 3295598,
       "required": true
     }
   ]

--- a/scripts/gregtech/recipes.zs
+++ b/scripts/gregtech/recipes.zs
@@ -37,45 +37,6 @@ static removeFurnace as IIngredient[] = [
 ];
 
 function machineRecipes() {
-    // make gold process MV
-    // !! convert to dupeForSmall on 0.21
-    gt.chemical_reactor.findRecipe(30, [<ore:ingotGoldAlloy>.firstItem * 4], [<liquid:water> * 1000, <liquid:nitric_acid> * 1000]).remove();
-    gt.large_chemical_reactor.findRecipe(30, [<ore:ingotGoldAlloy>.firstItem * 4], [<liquid:water> * 1000, <liquid:nitric_acid> * 1000]).remove();
-    gt.chemical_reactor.recipeBuilder()
-        .inputs([<ore:ingotGoldAlloy> * 4])
-        .fluidInputs([<liquid:water> * 1000, <liquid:nitric_acid> * 1000])
-        .outputs([<ore:dustGoldLeach>.firstItem])
-        .fluidOutputs([<liquid:nitrogen_dioxide> * 1000, <liquid:precious_leach_nitrate> * 3000])
-        .EUt(40).duration(sec(40))
-        .buildAndRegister();
-    gt.large_chemical_reactor.recipeBuilder()
-        .inputs([<ore:ingotGoldAlloy> * 4])
-        .fluidInputs([<liquid:water> * 1000, <liquid:nitric_acid> * 1000])
-        .outputs([<ore:dustGoldLeach>.firstItem])
-        .fluidOutputs([<liquid:nitrogen_dioxide> * 1000, <liquid:precious_leach_nitrate> * 3000])
-        .EUt(40).duration(sec(40))
-        .buildAndRegister();
-
-    gt.chemical_reactor.findRecipe(30, [<ore:dustGoldLeach>.firstItem], [<liquid:aqua_regia> * 1000, <liquid:sulfuric_acid> * 1000]).remove();
-    gt.large_chemical_reactor.findRecipe(30, [<ore:dustGoldLeach>.firstItem], [<liquid:aqua_regia> * 1000, <liquid:sulfuric_acid> * 1000]).remove();
-    gt.chemical_reactor.recipeBuilder()
-        .inputs([<ore:dustGoldLeach>])
-        .fluidInputs([<liquid:aqua_regia> * 1000, <liquid:sulfuric_acid> * 1000])
-        .chancedOutput(<ore:dustTinyLeadNitrate>.firstItem, 10 * 100, 0)
-        .fluidOutputs([<liquid:chloroauric_acid> * 1000, <liquid:nitrogen_dioxide> * 1000])
-        .EUt(40).duration(sec(40))
-        .buildAndRegister();
-    gt.large_chemical_reactor.recipeBuilder()
-        .inputs([<ore:dustGoldLeach>])
-        .fluidInputs([<liquid:aqua_regia> * 1000, <liquid:sulfuric_acid> * 1000])
-        .chancedOutput(<ore:dustTinyLeadNitrate>.firstItem, 10 * 100, 0)
-        .fluidOutputs([<liquid:chloroauric_acid> * 1000, <liquid:nitrogen_dioxide> * 1000])
-        .EUt(40).duration(sec(40))
-        .buildAndRegister();
-
-    //Compressed Fireclay
-    //Utils.removeRecipeByOutput(gt.compressor, [<gregtech:meta_item_2:32014>], [], false); //Compressed Fireclay
-    //furnace.addRecipe(<gregtech:meta_item_2:32015>, <gtadditions:ga_meta_item:32037>);
 
     val lvCables as string[] = [
         "Cobalt",


### PR DESCRIPTION
This PR updates GTCE and Gregicality to latest releases (1.14.0 and 0.22.2 respectively). I removed the Gold Chain script overrides as the process was reworked significantly in the mod, so the changes are no longer necessary. Additionally, I updated the quests for 3 main reasons:
- Update Crystal Circuits to use the new Kapton Circuit Board, and move the Master Circuit Board to Wetware circuits
- Add Steam Multiblock quests to the Steam Era page
- Add some of the missing elements into the periodic table page, and add Periodicium to the "Collector of the Elements" quest