### PR TITLE
Fix EnderIO port

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -675,6 +675,11 @@
       "projectID": 304346,
       "fileID": 3124450,
       "required": true
-    }
+    },
+    {
+      "projectID": 231868,
+      "fileID": 2972849,
+      "required": true
+    }	
   ]
 }

--- a/scripts/custom_materials.zs
+++ b/scripts/custom_materials.zs
@@ -1,0 +1,19 @@
+#loader gregtech
+#priority 1000
+
+import mods.gtadditions.recipe.Utils;
+import mods.contenttweaker.Fluid;
+import mods.contenttweaker.VanillaFactory;
+
+Utils.registerItem("end_steel", 1005, 0xece7b6, "METALLIC", "stick");
+Utils.registerItem("end_steel", 1006, 0xece7b6, "METALLIC", "plate");
+Utils.registerItem("end_steel", 1007, 0xece7b6, "METALLIC", "bolt");
+Utils.registerItem("end_steel", 1008, 0xece7b6, "METALLIC", "screw");
+Utils.registerItem("dark_steel", 1009, 0x2c2c2c, "DULL", "stick");
+Utils.registerItem("dark_steel", 1010, 0x2c2c2c, "DULL", "plate");
+Utils.registerItem("dark_steel", 1011, 0x2c2c2c, "DULL", "screw");
+Utils.registerItem("dark_steel", 1012, 0x2c2c2c, "DULL", "dust");
+Utils.registerItem("dark_steel", 1013, 0x2c2c2c, "DULL", "bolt");
+Utils.registerItem("stellar_alloy", 1014, 0xc4ccbf, "SHINY", "plate");
+Utils.registerItem("stellar_alloy", 1015, 0xc4ccbf, "SHINY", "bolt");
+Utils.registerItem("stellar_alloy", 1016, 0xc4ccbf, "SHINY", "screw");


### PR DESCRIPTION
This particular PR addresses two issues that recently arose.

1. This project did not include the EnderCore mod within the manifest, which appeared to cause issues for people attempting to make a server pack out of this, which appears to not download dependencies quite as easily.

2. The EnderIO scripts also were missing the custom materials that were used for them, and this PR thus adds a short custom_materials.zs file to fix the problem.