### PR TITLE
Turn on GregTech 6 style pipes and cables

### DIFF
--- a/config/gregtech.cfg
+++ b/config/gregtech.cfg
@@ -287,7 +287,7 @@ general {
 
         # Whether to use GT6-style pipe and cable connections, meaning they will not auto-connect unless placed directly onto another pipe or cable.
         # Default: true
-        B:gt6StylePipesCables=false
+        B:gt6StylePipesCables=true
 
         # Whether to play machine sounds while machines are active.
         # Default: true
@@ -586,5 +586,3 @@ general {
     }
 
 }
-
-


### PR DESCRIPTION
GT6 pipes and cables should always be turned on because:
  - It gives players more control over their actions.
  - It makes players think twice before connecting pipes and especially wires, which may prevent accidental explosions or other mistakes that break setups.
  - It's just more logical.

I will admit that, on the other hand, connecting pipes and wires costs some durability on tools, and takes a bit of time, but that's negligible. It will take 1 minute and 6 ingots to make a new tool, but it will take much more resources and nerves to rebuild a whole setup if pipes or wires accidentally connect where they shouldn't