### PR TITLE
Updated AE2, fixed AE2 energy cell CraftTweaker recipe

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -47,7 +47,7 @@
       },
       {
          "projectID":570458,
-         "fileID":3785381,
+         "fileID":3791235,
          "required":true
       },
       {

--- a/scripts/ae2/blocks.zs
+++ b/scripts/ae2/blocks.zs
@@ -91,9 +91,9 @@ recipes.addShaped("quantum_link", <appliedenergistics2:quantum_link>,
 // Energy cell recipe.
 recipes.remove(<appliedenergistics2:energy_cell>);
 recipes.addShaped("energy_cell", <appliedenergistics2:energy_cell>,
- [[<ore:plateAluminium>,<ore:batteryGood>,<ore:plateAluminium>],
-  [<ore:batteryGood>,<metaitem:battery_buffer.mv.4>,<ore:batteryGood>],
-  [<ore:plateAluminium>,<ore:batteryGood>,<ore:plateAluminium>]]);
+ [[<ore:plateAluminium>,<ore:batteryMv>,<ore:plateAluminium>],
+  [<ore:batteryMv>,<metaitem:battery_buffer.mv.4>,<ore:batteryMv>],
+  [<ore:plateAluminium>,<ore:batteryMv>,<ore:plateAluminium>]]);
 
 // Dense energy cell recipe.
 recipes.remove(<appliedenergistics2:dense_energy_cell>);


### PR DESCRIPTION
I've tested this in singleplayer and it seems to fix the crash bug caused by using the molecular assembler. Also while I'm at it I changed the craft tweaker recipe for AE2 energy cells to use ore:batteryMv instead of ore:batteryGood, which makes them craftable.